### PR TITLE
Add option for "latest" tag

### DIFF
--- a/.github/workflows/releasetracker.yml
+++ b/.github/workflows/releasetracker.yml
@@ -21,3 +21,5 @@ jobs:
         uses: bewuethr/release-tracker-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          update-latest: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # release-tracker-action
 
-[![Lint code base](https://github.com/bewuethr/release-tracker-action/actions/workflows/lint.yml/badge.svg)](https://github.com/bewuethr/release-tracker-action/actions/workflows/lint.yml)
-[![Move release tags](https://github.com/bewuethr/release-tracker-action/actions/workflows/releasetracker.yml/badge.svg)](https://github.com/bewuethr/release-tracker-action/actions/workflows/releasetracker.yml)
+[![Lint code base][lintflow]][lintbadge]
+[![Move release tags][moveflow]][movebadge]
+
+[lintflow]:  <https://github.com/bewuethr/release-tracker-action/actions/workflows/lint.yml>
+[lintbadge]: <https://github.com/bewuethr/release-tracker-action/actions/workflows/lint.yml/badge.svg>
+[moveflow]:  <https://github.com/bewuethr/release-tracker-action/actions/workflows/releasetracker.yml>
+[movebadge]: <https://github.com/bewuethr/release-tracker-action/actions/workflows/releasetracker.yml/badge.svg>
 
 This action finds the most recent major and minor release tags and creates
 or moves tags to point at them.
@@ -41,7 +46,7 @@ v1.0.0
 v1.0.1 <-- v1.0
 v1.1.0
 v1.1.1
-v1.1.2 <-- v1.1 <-- v1
+v1.1.2 <-- v1.1 <-- v1 <-- latest
 ```
 
 The new tags point at what the existing tags point at, not at the tags
@@ -58,6 +63,14 @@ just like the actions provided by GitHub itself do.
 If a tag exists already, it is deleted and re-created, pointing at the
 correct most recent release.
 
+## Inputs
+
+### `update-latest`
+
+**Optional** If `true`, a special tag `latest` is updated to point at the most
+recent semver tag overall. This updates across major versions, i.e., might
+break a workflow. Default `false`.
+
 ## Example usage
 
 It makes sense to run this action only when a new semantic versioning tag
@@ -71,16 +84,17 @@ The action runs on itself and the current major release is `v1`.
 A workflow using this action might look like this:
 
 ```yaml
+name: Update release tags
+
 # Only run when new semver tag is pushed
 on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
-name: Move release tags
-
 jobs:
   update-release-tags:
+    name: Update tags
     runs-on: ubuntu-latest
     steps:
 
@@ -89,9 +103,13 @@ jobs:
         with:
           # Get complete history
           fetch-depth: 0
-          # Always check out a branch
-          ref: main
 
-      - name: Update release tags for latest major and minor releases
+      - name: Update vX, vX.Y, and latest tags
         uses: bewuethr/release-tracker-action@v1
+        env:
+          # GitHub token to enable pushing tags
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Move "latest" tag
+          update-latest: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,20 @@ branding:
   icon: tag
   color: blue
 
+inputs:
+  update-latest:
+    description: Update a "latest" tag
+    required: false
+    default: false
+
 runs:
   using: composite
 
   steps:
     - name: Run tag updater
-      run: ${{ github.action_path }}/tagupdater
       shell: bash
+      run: |
+        if [[ ${{ inputs.update-latest }} == 'true' ]]; then
+            params+=('-l')
+        fi
+        '${{ github.action_path }}/tagupdater' "${params[@]}"

--- a/tagupdater
+++ b/tagupdater
@@ -48,7 +48,7 @@ main() {
 	git fetch --tags --force
 
 	# Build associative array of most recent major and minor releases
-	declare -A latest
+	local -A latest
 
 	echo "Building tag table..."
 	local major minor patch

--- a/tagupdater
+++ b/tagupdater
@@ -4,6 +4,10 @@
 gettags() {
 	git tag --list --sort='version:refname' 'v*.*.*'
 }
+
+# Get latest semver tag
+getlatesttag() {
+	gettags | head --lines=1
 }
 
 # Get SHA of object ref points to
@@ -40,6 +44,18 @@ createannotatedtag() {
 }
 
 main() {
+	# Parse options
+	local opt updatelatest
+	while getopts 'l' opt; do
+		case $opt in
+			l) updatelatest='true' ;;
+			'?')
+				echo "invalid option in $*" >&2
+				exit 1
+				;;
+		esac
+	done
+
 	# Set git name and email
 	git config --global user.name "github-actions"
 	git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -56,6 +72,11 @@ main() {
 		latest["$major"]="$major.$minor.$patch"
 		latest["$major.$minor"]="$major.$minor.$patch"
 	done < <(gettags)
+
+	# Add "latest" tag if there are tags and the option is set
+	if ((${#latest[@]})) && [[ $updatelatest == 'true' ]]; then
+		latest['latest']=$(getlatesttag)
+	fi
 
 	# Move or create tags
 	local tag semvertag

--- a/tagupdater
+++ b/tagupdater
@@ -7,7 +7,7 @@ gettags() {
 
 # Get latest semver tag
 getlatesttag() {
-	gettags | head --lines=1
+	gettags | tail --lines=1
 }
 
 # Get SHA of object ref points to

--- a/tagupdater
+++ b/tagupdater
@@ -2,8 +2,8 @@
 
 # List all semver tags and sort them
 gettags() {
-	git tag --list 'v*.*.*' \
-		| sort --version-sort
+	git tag --list --sort='version:refname' 'v*.*.*'
+}
 }
 
 # Get SHA of object ref points to


### PR DESCRIPTION
When the `update-latest` option is `true`, this updates a `latest` tag to point to the latest semver tag in the repository. The option is not required and defaults to `false` to retain backwards compatibility.

Closes #5