### PR TITLE
Ignore pre-release tags

### DIFF
--- a/tagupdater
+++ b/tagupdater
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-# List all semver tags and sort them
+# List all semver tags and sort them; exclude pre-release tags
 gettags() {
-	git tag --list --sort='version:refname' 'v*.*.*'
+	git tag --list --sort='version:refname' 'v*.*.*' \
+		| grep --extended-regexp '^v([[:digit:]]+\.){2}[[:digit:]]+$'
 }
 
 # Get latest semver tag


### PR DESCRIPTION
When switching to using a glob with `git tag --list` instead of filtering its output (and also leaving the `v` in place) in 0bcd822, the filtering became less strict and allowed tags such as `v.1.2.3-pre` to be matched as well, which is fixed in this PR.

Fixes #15