### PR TITLE
Support tags without "v"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2022 Benjamin Wuethrich
+Copyright (c) 2020-2023 Benjamin Wuethrich
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -76,6 +76,31 @@ break a workflow. Default `false`.
 **Optional** If `true`, the tags with the format `vX.Y` to point at the most
 recent patch version within a minor version are updated. Default `true`.
 
+### `prepend-v`
+
+**Optional** If `true`, tags are expected to look like `vX.Y.Z`, and the moving
+tags like `vX.Y` (if enabled) and `vX`. If `false`, the "v" is dropped, and
+tags look like `X.Y.Z`, `X.Y`, and `X`:
+
+```txt
+0.1.0
+0.1.1
+0.1.2
+0.1.3 <-- 0.1
+0.2.0
+0.2.1
+0.2.2
+0.2.3
+0.2.4 <-- 0.2 <-- 0
+1.0.0
+1.0.1 <-- 1.0
+1.1.0
+1.1.1
+1.1.2 <-- 1.1 <-- 1 <-- latest
+```
+
+Default `true`.
+
 ## Example usage
 
 It makes sense to run this action only when a new semantic versioning tag
@@ -95,6 +120,7 @@ name: Update release tags
 on:
   push:
     tags:
+      # Switch to '[0-9]+.[0-9]+.[0-9]+' if prepend-v is false
       - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
@@ -119,4 +145,6 @@ jobs:
           update-latest: true
           # Don't update the vX.Y tags
           update-minor: false
+          # Expect vX.Y.Z format (default)
+          prepend-v: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,11 @@ inputs:
     required: false
     default: true
 
+  prepend-v:
+    description: Create tags in vX.Y.Z format
+    required: false
+    default: true
+
 runs:
   using: composite
 
@@ -28,6 +33,7 @@ runs:
       env:
         latest: ${{ inputs.update-latest }}
         minor: ${{ inputs.update-minor }}
+        prependv: ${{ inputs.prepend-v }}
       run: |
         if [[ $latest == 'true' ]]; then
             params+=('-l')
@@ -35,6 +41,10 @@ runs:
 
         if [[ $minor == 'true' ]]; then
             params+=('-m')
+        fi
+
+        if [[ $prependv == 'false' ]]; then
+            params+=('-v')
         fi
 
         "$GITHUB_ACTION_PATH/tagupdater" "${params[@]}"

--- a/tagupdater
+++ b/tagupdater
@@ -2,13 +2,15 @@
 
 # List all semver tags and sort them; exclude pre-release tags
 gettags() {
-	git tag --list --sort='version:refname' 'v*.*.*' \
-		| grep --extended-regexp '^v([[:digit:]]+\.){2}[[:digit:]]+$'
+	local prefix=$1
+	git tag --list --sort='version:refname' "$prefix*.*.*" \
+		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+$"
 }
 
 # Get latest semver tag
 getlatesttag() {
-	gettags | tail --lines=1
+	local prefix=$1
+	gettags "$prefix" | tail --lines=1
 }
 
 # Get SHA of object ref points to
@@ -46,11 +48,13 @@ createannotatedtag() {
 
 main() {
 	# Parse options
-	local opt updatelatest updateminor
-	while getopts 'lm' opt; do
+	local opt updatelatest updateminor prefix
+	prefix='v'
+	while getopts 'lmv' opt; do
 		case $opt in
 			l) updatelatest='true' ;;
 			m) updateminor='true' ;;
+			v) prefix='' ;;
 			'?') exit 1 ;;
 		esac
 	done
@@ -70,11 +74,11 @@ main() {
 	while IFS=. read -r major minor patch; do
 		latest["$major"]="$major.$minor.$patch"
 		[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
-	done < <(gettags)
+	done < <(gettags "$prefix")
 
 	# Add "latest" tag if there are tags and the option is set
 	if ((${#latest[@]})) && [[ $updatelatest == 'true' ]]; then
-		latest['latest']=$(getlatesttag)
+		latest['latest']=$(getlatesttag "$prefix")
 	fi
 
 	# Move or create tags


### PR DESCRIPTION
Add a `prepend-v` option (defaults to `true`) to control if tags look like `vX.Y.Z` or just `X.Y.Z`.