### PR TITLE
Add write permissions to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ jobs:
   update-release-tags:
     name: Update tags
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Get complete history
           fetch-depth: 0


### PR DESCRIPTION
Adding write permissions allows this GitHub Action to work out of the box with any git setup.

The upgrade to actions/checkout#v4 is unnecessary, but a nice touch.