### PR TITLE
Add prerelease support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,34 +101,6 @@ tags look like `X.Y.Z`, `X.Y`, and `X`:
 
 Default `true`.
 
-### `pre-release-versions`
-
-**Optional** `"['beta', 'alpha']"` will take into account the pre-releases `beta` and `alpha` and allow your tags to point at these pre-release versions. Note that tags will always prefer the latest stable version:
-
-```txt
-0.1.0
-0.1.1
-0.1.2
-0.1.3         <-- 0.1
-0.1.4-beta
-0.2.0
-0.2.1
-0.2.2
-0.2.3
-0.2.4         <-- 0.2 <-- 0
-0.3.0-beta
-0.3.0-beta.2  <-- 0.3
-0.3.1-alpha
-1.0.0
-1.0.1         <-- 1.0
-1.1.0
-1.1.1
-1.1.2         <-- 1.1 <-- 1 <-- latest
-1.2.1-alpha
-1.2.1-alpha.2
-1.2.2-alpha   <-- 1.2
-```
-
 ## Example usage
 
 It makes sense to run this action only when a new semantic versioning tag
@@ -151,11 +123,8 @@ on:
       # Switch to '[0-9]+.[0-9]+.[0-9]+' (including the quotes!) if prepend-v
       # is false
       - v[0-9]+.[0-9]+.[0-9]+
-      # To support pre-release versions, add the following lines
-      - v[0-9]+.[0-9]+.[0-9]+-alpha
-      - v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+-beta
-      - v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+
+      # To support minor pre-release tags, add the following lines and set update-minor to true
+      - v[0-9]+.[0-9]+.[0-9]+-*
 
 jobs:
   update-release-tags:
@@ -183,6 +152,4 @@ jobs:
           update-minor: false
           # Expect vX.Y.Z format (default)
           prepend-v: true
-          # Specify precedence of your pre-release versions
-          pre-release-versions: "['beta', 'alpha']"
 ```

--- a/README.md
+++ b/README.md
@@ -101,6 +101,34 @@ tags look like `X.Y.Z`, `X.Y`, and `X`:
 
 Default `true`.
 
+### `pre-release-versions`
+
+**Optional** `"['beta', 'alpha']"` will take into account the pre-releases `beta` and `alpha` and allow your tags to point at these pre-release versions. Note that tags will always prefer the latest stable version:
+
+```txt
+0.1.0
+0.1.1
+0.1.2
+0.1.3         <-- 0.1
+0.1.4-beta
+0.2.0
+0.2.1
+0.2.2
+0.2.3
+0.2.4         <-- 0.2 <-- 0
+0.3.0-beta
+0.3.0-beta.2  <-- 0.3
+0.3.1-alpha
+1.0.0
+1.0.1         <-- 1.0
+1.1.0
+1.1.1
+1.1.2         <-- 1.1 <-- 1 <-- latest
+1.2.1-alpha
+1.2.1-alpha.2
+1.2.2-alpha   <-- 1.2
+```
+
 ## Example usage
 
 It makes sense to run this action only when a new semantic versioning tag
@@ -123,6 +151,11 @@ on:
       # Switch to '[0-9]+.[0-9]+.[0-9]+' (including the quotes!) if prepend-v
       # is false
       - v[0-9]+.[0-9]+.[0-9]+
+      # To support pre-release versions, add the following lines
+      - v[0-9]+.[0-9]+.[0-9]+-alpha
+      - v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-beta
+      - v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+
 
 jobs:
   update-release-tags:
@@ -150,4 +183,6 @@ jobs:
           update-minor: false
           # Expect vX.Y.Z format (default)
           prepend-v: true
+          # Specify precedence of your pre-release versions
+          pre-release-versions: "['beta', 'alpha']"
 ```

--- a/action.yml
+++ b/action.yml
@@ -10,19 +10,28 @@ branding:
 
 inputs:
   update-latest:
+    type: boolean
     description: Update a "latest" tag
     required: false
     default: false
 
   update-minor:
+    type: boolean
     description: Update vX.Y tags
     required: false
     default: true
 
   prepend-v:
+    type: boolean
     description: Create tags in vX.Y.Z format
     required: false
     default: true
+
+  pre-release-versions:
+    type: string
+    description: Create tags for pre-release versions. Input as array in order of specificity, e.g. "['beta', 'alpha']"
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -34,6 +43,7 @@ runs:
         latest: ${{ inputs.update-latest }}
         minor: ${{ inputs.update-minor }}
         prependv: ${{ inputs.prepend-v }}
+        prereleaseversions: ${{ inputs.pre-release-versions }}
       run: |
         if [[ $latest == 'true' ]]; then
             params+=('-l')
@@ -46,5 +56,7 @@ runs:
         if [[ $prependv == 'false' ]]; then
             params+=('-v')
         fi
+
+        !!!ADD PRE-RELEASE VERSIONS TO PARAMS!!!
 
         "$GITHUB_ACTION_PATH/tagupdater" "${params[@]}"

--- a/action.yml
+++ b/action.yml
@@ -27,12 +27,6 @@ inputs:
     required: false
     default: true
 
-  pre-release-versions:
-    type: string
-    description: Create tags for pre-release versions. Input as array in order of specificity, e.g. "['beta', 'alpha']"
-    required: false
-    default: ""
-
 runs:
   using: composite
 
@@ -43,7 +37,6 @@ runs:
         latest: ${{ inputs.update-latest }}
         minor: ${{ inputs.update-minor }}
         prependv: ${{ inputs.prepend-v }}
-        prereleaseversions: ${{ inputs.pre-release-versions }}
       run: |
         if [[ $latest == 'true' ]]; then
             params+=('-l')
@@ -56,7 +49,5 @@ runs:
         if [[ $prependv == 'false' ]]; then
             params+=('-v')
         fi
-
-        params+=($prereleaseversions)
 
         "$GITHUB_ACTION_PATH/tagupdater" "${params[@]}"

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,6 @@ runs:
             params+=('-v')
         fi
 
-        !!!ADD PRE-RELEASE VERSIONS TO PARAMS!!!
+        params+=($prereleaseversions)
 
         "$GITHUB_ACTION_PATH/tagupdater" "${params[@]}"

--- a/tagupdater
+++ b/tagupdater
@@ -11,7 +11,7 @@ gettags() {
 	local alphanumeric="($identifier*$nondigit$identifier*)"
 	local prerelease="($alphanumeric|$numeric)"
 
-	local semverregex="$prefix([[:digit:]]+\.){2}[[:digit:]]+"
+	local semverregex="$prefix($numeric+\.){2}$numeric+"
 	local preregex="(-$prerelease(\.$prerelease)*)"
 	local regex="^$semverregex$preregex?$"
 

--- a/tagupdater
+++ b/tagupdater
@@ -5,8 +5,8 @@ gettags() {
 	local prefix=$1
 	git tag --list --sort='version:refname' "$prefix*.*.*" \
 		| grep --extended-regexp "{(?x)^$prefix([[:digit:]]+\.){2}[[:digit:]]+
-					  (-([[:alpha:]]+|(0|[1-9][0-9]*)))?
-					  ((\.|-)+([[:alpha:]]?|(0|[1-9][0-9]*)))*$}"
+					  (-([[:alpha:]]+|(0|[1-9][0-9]*))
+					  ((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$}"
 }
 
 # Get SHA of object ref points to
@@ -66,14 +66,20 @@ main() {
 	local -A latest
 
 	echo "Building tag table..."
-	local major minor patch pre prepatch
+	local semver pretag major minor patch
+
+	while IFS=- read -r semver pretag <<< "$s" ; do
+		echo semver-pretag
+	done < <(gettags "$prefix")
+
 	while IFS=".""-" read -r major minor patch pre prepatch ; do
 		if [[ ! $pre ]]; then
 			latest["$major"]="$major.$minor.$patch"
 			[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
 			[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
-		elif [[ $prepatch ]]; then latest["$major.$minor-pre"]="$major.$minor.$patch-$pre.$prepatch"
-		else latest["$major.$minor-pre"]="$major.$minor.$patch-$pre"; fi
+		elif [[ $updateminor == 'true' ]]; then 
+			[[ $prepatch ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pre.$prepatch" || latest["$major.$minor-pre"]="$major.$minor.$patch-$pre"
+		fi
 	done < <(gettags "$prefix")
 
 	# Move or create tags

--- a/tagupdater
+++ b/tagupdater
@@ -75,7 +75,7 @@ main() {
 		[[ ! $pre ]] && latest["$major"]="$major.$minor.$patch"
 		[[ ! $pre ]] && [[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
 		[[ $pre ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pre"
-		[[ $pre ]] && [[ $prepatch ]] latest["$major.$minor-pre"]="$major.$minor.$patch-$pre.$prepatch"
+		[[ $pre ]] && [[ $prepatch ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pre.$prepatch"
 	done < <(gettags "$prefix")
 
 	# Add "latest" tag if there are tags and the option is set

--- a/tagupdater
+++ b/tagupdater
@@ -72,7 +72,7 @@ main() {
 	echo "Building tag table..."
 	local tag semvertag pretag
 	local major minor patch
-	for tag in $(gettags "$prefix") do
+	for tag in $(gettags "$prefix"); do
 		echo "$tag"
 		IFS=- read -r semvertag pretag <<< "$tag"
 		while IFS=. read -r major minor patch ; do

--- a/tagupdater
+++ b/tagupdater
@@ -68,9 +68,9 @@ main() {
 	echo "Building tag table..."
 	local tag semvertag pretag
 	local semver major minor patch
-	for tag in $(gettags $prefix); do
+	for tag; do
 		echo "$tag"
-	done
+	done < <(gettags "$prefix")
 
 	#while IFS=- read -r semver pretag <<< "$s" ; do
 	#	echo "$semver-$pretag"

--- a/tagupdater
+++ b/tagupdater
@@ -68,7 +68,7 @@ main() {
 	echo "Building tag table..."
 	local tag semvertag pretag
 	local semver major minor patch
-	for tag in (gettags $prefix); do
+	for tag in $(gettags $prefix); do
 		echo "$tag"
 	done
 

--- a/tagupdater
+++ b/tagupdater
@@ -3,10 +3,16 @@
 # List all semver tags and sort them
 gettags() {
 	local prefix=$1
+
+	local regex
+	$ regex="^$prefix([[:digit:]]+\.){2}[[:digit:]]+"\
+	> "(-([[:alpha:]]+|(0|[1-9][0-9]*))"\
+	> "((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$}"
+
+	echo "$regex"
+
 	git tag --list --sort='version:refname' "$prefix*.*.*" \
-		| grep --extended-regexp '{(?x)^$prefix([[:digit:]]+\.){2}[[:digit:]]+
-					  (-([[:alpha:]]+|(0|[1-9][0-9]*))
-					  ((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$}'
+		| grep --extended-regexp "$regex"
 }
 
 # Get SHA of object ref points to

--- a/tagupdater
+++ b/tagupdater
@@ -75,13 +75,13 @@ main() {
 	for tag in $(gettags "$prefix"); do
 		echo "$tag"
 		IFS=- read -r semvertag pretag <<< "$tag"
-		while IFS=. read major minor patch <<< "$semvertag"; do
-			if [[ ! pretag ]]; then
-				latest["$major"]="$major.$minor.$patch"
-				[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
-				[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
-			else [[ $updateminor == 'true' ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pretag"; fi
-		done
+		IFS=. read -r major semvertag <<< "$semvertag";
+		IFS=. read -r minor patch <<< "$semvertag";
+		if [[ ! pretag ]]; then
+			latest["$major"]="$major.$minor.$patch"
+			[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
+			[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
+		else [[ $updateminor == 'true' ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pretag"; fi
 	done
 
 	# Move or create tags

--- a/tagupdater
+++ b/tagupdater
@@ -11,7 +11,7 @@ gettags() {
 getpretags() {
 	local prefix=$1
 	git tag --list --sort='version:refname' "$prefix*.*.*-*" \
-		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+-[[:alpha:]]+(\.[[:digit]]+)?$"
+		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+-[[:alpha:]]+(\.[[:digit:]]+)?$"
 }
 
 # Get latest semver tag

--- a/tagupdater
+++ b/tagupdater
@@ -9,7 +9,7 @@ gettags() {
 	regex+="(-([[:alpha:]]+|(0|[1-9][0-9]*))"
 	regex+="((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$}"
 
-	git tag --list --sort='version:refname' "$prefix*.*.*" \
+	git tag --list --sort='version:refname' "$prefix*.*.*-*" \
 		| grep --extended-regexp "$regex"
 }
 

--- a/tagupdater
+++ b/tagupdater
@@ -71,7 +71,7 @@ main() {
 			[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
 			[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
 		elif [[ $prepatch ]]; then latest["$major.$minor-pre"]="$major.$minor.$patch-$pre.$prepatch"
-		else latest["$major.$minor-pre"]="$major.$minor.$patch-$pre" fi
+		else latest["$major.$minor-pre"]="$major.$minor.$patch-$pre"; fi
 	done < <(gettags "$prefix")
 
 	# Move or create tags

--- a/tagupdater
+++ b/tagupdater
@@ -4,7 +4,8 @@
 gettags() {
 	local prefix=$1
 	git tag --list --sort='version:refname' "$prefix*.*.*" \
-		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+$"
+		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+"
+
 }
 
 # Get latest semver tag
@@ -71,7 +72,8 @@ main() {
 
 	echo "Building tag table..."
 	local major minor patch
-	while IFS=. read -r major minor patch; do
+	while IFS=".""-" read -r major minor patch pre prepatch ; do
+		echo "$major.$minor.$patch-$pre.$prepatch"
 		latest["$major"]="$major.$minor.$patch"
 		[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
 	done < <(gettags "$prefix")

--- a/tagupdater
+++ b/tagupdater
@@ -7,12 +7,6 @@ gettags() {
 		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+(-[[:alpha:]]+(\.[[:digit:]]+)?)?$"
 }
 
-# Get latest semver tag
-getlatesttag() {
-	local prefix=$1
-	gettags "$prefix" | tail --lines=1
-}
-
 # Get SHA of object ref points to
 getparentsha() {
 	local ref=$1
@@ -72,16 +66,13 @@ main() {
 	echo "Building tag table..."
 	local major minor patch pre prepatch
 	while IFS=".""-" read -r major minor patch pre prepatch ; do
-		[[ ! $pre ]] && latest["$major"]="$major.$minor.$patch"
-		[[ ! $pre ]] && [[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
-		[[ $pre ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pre"
-		[[ $pre ]] && [[ $prepatch ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pre.$prepatch"
+		if [[ ! $pre ]]
+			latest["$major"]="$major.$minor.$patch"
+			[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
+			[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
+		elif [[ $prepatch ]]; then latest["$major.$minor-pre"]="$major.$minor.$patch-$pre.$prepatch"
+		else latest["$major.$minor-pre"]="$major.$minor.$patch-$pre" fi
 	done < <(gettags "$prefix")
-
-	# Add "latest" tag if there are tags and the option is set
-	if ((${#latest[@]})) && [[ $updatelatest == 'true' ]]; then
-		latest['latest']=$(getlatesttag "$prefix")
-	fi
 
 	# Move or create tags
 	local tag semvertag

--- a/tagupdater
+++ b/tagupdater
@@ -11,7 +11,7 @@ gettags() {
 	local alphanumeric="($identifier*$nondigit$identifier*)"
 	local prerelease="($alphanumeric|$numeric)"
 
-	local semverregex="$prefix($numeric+\.){2}$numeric+"
+	local semverregex="$prefix($numeric\.){2}$numeric"
 	local preregex="(-$prerelease(\.$prerelease)*)"
 	local regex="^$semverregex$preregex?$"
 

--- a/tagupdater
+++ b/tagupdater
@@ -4,8 +4,13 @@
 gettags() {
 	local prefix=$1
 	git tag --list --sort='version:refname' "$prefix*.*.*" \
-		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+"
+		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+$"
+}
 
+getpretags() {
+	local prefix=$1
+	git tag --list --sort='version:refname' "$prefix*.*.*-*" \
+		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+-[[:alpha:]](\.[[:digit]]+)?$"
 }
 
 # Get latest semver tag
@@ -72,8 +77,7 @@ main() {
 
 	echo "Building tag table..."
 	local major minor patch
-	while IFS=".""-" read -r major minor patch pre prepatch ; do
-		echo "$major.$minor.$patch-$pre.$prepatch"
+	while IFS=. read -r major minor patch ; do
 		latest["$major"]="$major.$minor.$patch"
 		[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
 	done < <(gettags "$prefix")
@@ -101,6 +105,20 @@ main() {
 		echo "Creating annotated tag $tag pointing to same commit as $semvertag..."
 		createannotatedtag "$tag" "$semvertag"
 	done
+
+	# Update prerelease tags
+	if [[ $updateminor == 'true' ]]; then
+		local -A latestpre
+		local pre prepatch
+		while IFS=".""-" read -r major minor patch pre prepatch ; do
+			echo $major.$minor.$patch-$pre.$prepatch
+			if [[ $prepatch ]]; then
+				latestpre["$major.$minor"]="$major.$minor.$patch-$pre.$prepatch"
+			elif
+				latestpre["$major.$minor"]="$major.$minor.$patch-$pre"
+			fi
+		done < <(getpretags "$prefix")
+	fi
 }
 
 [[ ${BASH_SOURCE[0]} == "$0" ]] && main "$@"

--- a/tagupdater
+++ b/tagupdater
@@ -7,10 +7,11 @@ gettags() {
 		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+$"
 }
 
+# List all pre-release semver tags and sort them
 getpretags() {
 	local prefix=$1
 	git tag --list --sort='version:refname' "$prefix*.*.*-*" \
-		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+-[[:alpha:]](\.[[:digit]]+)?$"
+		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+-[[:alpha:]]+(\.[[:digit]]+)?$"
 }
 
 # Get latest semver tag
@@ -46,10 +47,10 @@ createannotatedtag() {
 
 	# Create tag reference
 	echo "Creating tag reference..."
-	gh api 'repos/{owner}/{repo}/git/refs' \
-		--raw-field "ref=refs/tags/$tag" \
-		--raw-field "sha=$tagsha" \
-		| jq .
+	#gh api 'repos/{owner}/{repo}/git/refs' \
+	#	--raw-field "ref=refs/tags/$tag" \
+	#	--raw-field "sha=$tagsha" \
+	#	| jq .
 }
 
 main() {

--- a/tagupdater
+++ b/tagupdater
@@ -4,7 +4,9 @@
 gettags() {
 	local prefix=$1
 	git tag --list --sort='version:refname' "$prefix*.*.*" \
-		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+(-[[:alpha:]]+(\.[[:digit:]]+)?)?$"
+		| grep --extended-regexp "{(?x)^$prefix([[:digit:]]+\.){2}[[:digit:]]+
+					  (-([[:alpha:]]+|(0|[1-9][0-9]*)))?
+					  ((\.|-)+([[:alpha:]]?|(0|[1-9][0-9]*)))*$}"
 }
 
 # Get SHA of object ref points to

--- a/tagupdater
+++ b/tagupdater
@@ -66,10 +66,14 @@ main() {
 	local -A latest
 
 	echo "Building tag table..."
-	local semver pretag major minor patch
+	local tag semvertag pretag
+	local semver major minor patch
+	#for tag in "${(gettags $prefix)}"; do
+	#	echo "$tag"
+	#done
 
 	while IFS=- read -r semver pretag <<< "$s" ; do
-		echo semver-pretag
+		echo "$semver-$pretag"
 	done < <(gettags "$prefix")
 
 	while IFS=".""-" read -r major minor patch pre prepatch ; do
@@ -83,7 +87,6 @@ main() {
 	done < <(gettags "$prefix")
 
 	# Move or create tags
-	local tag semvertag
 	for tag in "${!latest[@]}"; do
 		echo "Checking $tag..."
 		semvertag=${latest["$tag"]}

--- a/tagupdater
+++ b/tagupdater
@@ -4,10 +4,17 @@
 gettags() {
 	local prefix=$1
 
-	local regex
-	regex="^$prefix([[:digit:]]+\.){2}[[:digit:]]+"
-	regex+="(-([[:alpha:]]+|(0|[1-9][0-9]*))"
-	regex+="((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$"
+	local numeric="(0|[1-9][0-9]*)"
+	local nondigit="([[:alpha:]]|-)"
+	local identifier="([[:digit:]]|$nondigit)"
+	local alphanumeric="($identifier*$nondigit$identifier*)"
+	local prerelease="($alphanumeric|$numeric)"
+
+	local semverregex="$prefix([[:digit:]]+\.){2}[[:digit:]]+"
+	local preregex="(-$prerelease(\.$prerelease)*)"
+	local regex="^$semverregex$preregex?$"
+
+	echo "$regex"
 
 	git tag --list --sort='version:refname' "$prefix*.*.*" \
 		| grep --extended-regexp "$regex"

--- a/tagupdater
+++ b/tagupdater
@@ -80,7 +80,7 @@ main() {
 				latest["$major"]="$major.$minor.$patch"
 				[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
 				[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
-			else [[ $updateminor == 'true' ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pretag; fi
+			else [[ $updateminor == 'true' ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pretag"; fi
 		done < "$semvertag"
 	done
 

--- a/tagupdater
+++ b/tagupdater
@@ -68,13 +68,13 @@ main() {
 	echo "Building tag table..."
 	local tag semvertag pretag
 	local semver major minor patch
-	#for tag in "${(gettags $prefix)}"; do
-	#	echo "$tag"
-	#done
+	for tag in (gettags $prefix); do
+		echo "$tag"
+	done
 
-	while IFS=- read -r semver pretag <<< "$s" ; do
-		echo "$semver-$pretag"
-	done < <(gettags "$prefix")
+	#while IFS=- read -r semver pretag <<< "$s" ; do
+	#	echo "$semver-$pretag"
+	#done < <(gettags "$prefix")
 
 	while IFS=".""-" read -r major minor patch pre prepatch ; do
 		if [[ ! $pre ]]; then

--- a/tagupdater
+++ b/tagupdater
@@ -9,8 +9,6 @@ gettags() {
 	regex+="(-([[:alpha:]]+|(0|[1-9][0-9]*))"
 	regex+="((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$}"
 
-	echo "$regex"
-
 	git tag --list --sort='version:refname' "$prefix*.*.*" \
 		| grep --extended-regexp "$regex"
 }
@@ -74,17 +72,17 @@ main() {
 	echo "Building tag table..."
 	local tag semvertag pretag
 	local major minor patch
-
-
-	while IFS=".""-" read -r major minor patch pre prepatch ; do
-		if [[ ! $pre ]]; then
-			latest["$major"]="$major.$minor.$patch"
-			[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
-			[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
-		elif [[ $updateminor == 'true' ]]; then 
-			[[ $prepatch ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pre.$prepatch" || latest["$major.$minor-pre"]="$major.$minor.$patch-$pre"
-		fi
-	done < <(gettags "$prefix")
+	for tag in $(gettags "$prefix") do
+		echo "$tag"
+		IFS=- read -r semvertag pretag <<< "$tag"
+		while IFS=. read -r major minor patch ; do
+			if [[ ! pretag ]]; then
+				latest["$major"]="$major.$minor.$patch"
+				[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
+				[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
+			else [[ $updateminor == 'true' ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pretag; fi
+		done < "$semvertag"
+	done
 
 	# Move or create tags
 	for tag in "${!latest[@]}"; do

--- a/tagupdater
+++ b/tagupdater
@@ -4,9 +4,9 @@
 gettags() {
 	local prefix=$1
 	git tag --list --sort='version:refname' "$prefix*.*.*" \
-		| grep --extended-regexp "{(?x)^$prefix([[:digit:]]+\.){2}[[:digit:]]+
+		| grep --extended-regexp '{(?x)^$prefix([[:digit:]]+\.){2}[[:digit:]]+
 					  (-([[:alpha:]]+|(0|[1-9][0-9]*))
-					  ((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$}"
+					  ((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$}'
 }
 
 # Get SHA of object ref points to

--- a/tagupdater
+++ b/tagupdater
@@ -112,11 +112,12 @@ main() {
 		local -A latestpre
 		local pre prepatch
 		while IFS=".""-" read -r major minor patch pre prepatch ; do
-			echo $major.$minor.$patch-$pre.$prepatch
 			if [[ $prepatch ]]; then
-				latestpre["$major.$minor"]="$major.$minor.$patch-$pre.$prepatch"
+				echo $major.$minor.$patch-$pre.$prepatch
+				latestpre["$major.$minor-pre"]="$major.$minor.$patch-$pre.$prepatch"
 			else
-				latestpre["$major.$minor"]="$major.$minor.$patch-$pre"
+				echo $major.$minor.$patch-$pre
+				latestpre["$major.$minor-pre"]="$major.$minor.$patch-$pre"
 			fi
 		done < <(getpretags "$prefix")
 	fi

--- a/tagupdater
+++ b/tagupdater
@@ -5,9 +5,9 @@ gettags() {
 	local prefix=$1
 
 	local regex
-	$ regex="^$prefix([[:digit:]]+\.){2}[[:digit:]]+"\
-	> "(-([[:alpha:]]+|(0|[1-9][0-9]*))"\
-	> "((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$}"
+	regex="^$prefix([[:digit:]]+\.){2}[[:digit:]]+"
+	regex+="(-([[:alpha:]]+|(0|[1-9][0-9]*))"
+	regex+="((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$}"
 
 	echo "$regex"
 

--- a/tagupdater
+++ b/tagupdater
@@ -7,7 +7,7 @@ gettags() {
 	local regex
 	regex="^$prefix([[:digit:]]+\.){2}[[:digit:]]+"
 	regex+="(-([[:alpha:]]+|(0|[1-9][0-9]*))"
-	regex+="((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$}"
+	regex+="((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$"
 
 	git tag --list --sort='version:refname' "$prefix*.*.*-*" \
 		| grep --extended-regexp "$regex"

--- a/tagupdater
+++ b/tagupdater
@@ -75,7 +75,7 @@ main() {
 	for tag in $(gettags "$prefix"); do
 		echo "$tag"
 		IFS=- read -r semvertag pretag <<< "$tag"
-		while IFS=. read -r major minor patch <<< "$semvertag" ; do
+		while IFS=. read major minor patch <<< "$semvertag"; do
 			if [[ ! pretag ]]; then
 				latest["$major"]="$major.$minor.$patch"
 				[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"

--- a/tagupdater
+++ b/tagupdater
@@ -67,10 +67,19 @@ main() {
 
 	echo "Building tag table..."
 	local tag semvertag pretag
-	local semver major minor patch
-	for tag; do
+	local major minor patch
+	for tag in gettags "$prefix" do
 		echo "$tag"
-	done < <(gettags "$prefix")
+		IFS=- read -r semvertag pretag <<< "$tag"
+
+		while IFS=. read -r major minor patch ; do
+			if [[ ! pretag ]]; then
+				latest["$major"]="$major.$minor.$patch"
+				[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
+				[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
+			else [[ $updateminor == 'true' ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pretag; fi
+		done < "$semvertag"
+	done
 
 	#while IFS=- read -r semver pretag <<< "$s" ; do
 	#	echo "$semver-$pretag"

--- a/tagupdater
+++ b/tagupdater
@@ -80,8 +80,8 @@ main() {
 	local major minor patch
 	for tag in $(gettags "$prefix"); do
 		IFS=- read -r semvertag pretag <<< "$tag"
-		IFS=. read -r major semvertag <<< "$semvertag";
-		IFS=. read -r minor patch <<< "$semvertag";
+		IFS=. read -r major semvertag <<< "$semvertag"
+		IFS=. read -r minor patch <<< "$semvertag"
 		if [[ ! $pretag ]]; then
 			latest["$major"]="$major.$minor.$patch"
 			[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"

--- a/tagupdater
+++ b/tagupdater
@@ -34,10 +34,10 @@ createannotatedtag() {
 
 	# Create tag reference
 	echo "Creating tag reference..."
-	#gh api 'repos/{owner}/{repo}/git/refs' \
-	#	--raw-field "ref=refs/tags/$tag" \
-	#	--raw-field "sha=$tagsha" \
-	#	| jq .
+	gh api 'repos/{owner}/{repo}/git/refs' \
+		--raw-field "ref=refs/tags/$tag" \
+		--raw-field "sha=$tagsha" \
+		| jq .
 }
 
 main() {

--- a/tagupdater
+++ b/tagupdater
@@ -9,7 +9,7 @@ gettags() {
 	regex+="(-([[:alpha:]]+|(0|[1-9][0-9]*))"
 	regex+="((\.|-)+([[:alpha:]]*|(0|[1-9][0-9]*)))*)?$"
 
-	git tag --list --sort='version:refname' "$prefix*.*.*-*" \
+	git tag --list --sort='version:refname' "$prefix*.*.*" \
 		| grep --extended-regexp "$regex"
 }
 

--- a/tagupdater
+++ b/tagupdater
@@ -75,13 +75,13 @@ main() {
 	for tag in $(gettags "$prefix"); do
 		echo "$tag"
 		IFS=- read -r semvertag pretag <<< "$tag"
-		while IFS=. read -r major minor patch ; do
+		while IFS=. read -r major minor patch <<< "$semvertag" ; do
 			if [[ ! pretag ]]; then
 				latest["$major"]="$major.$minor.$patch"
 				[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
 				[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
 			else [[ $updateminor == 'true' ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pretag"; fi
-		done < "$semvertag"
+		done
 	done
 
 	# Move or create tags

--- a/tagupdater
+++ b/tagupdater
@@ -1,17 +1,10 @@
 #!/usr/bin/env bash
 
-# List all semver tags and sort them; exclude pre-release tags
+# List all semver tags and sort them
 gettags() {
 	local prefix=$1
 	git tag --list --sort='version:refname' "$prefix*.*.*" \
-		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+$"
-}
-
-# List all pre-release semver tags and sort them
-getpretags() {
-	local prefix=$1
-	git tag --list --sort='version:refname' "$prefix*.*.*-*" \
-		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+-[[:alpha:]]+(\.[[:digit:]]+)?$"
+		| grep --extended-regexp "^$prefix([[:digit:]]+\.){2}[[:digit:]]+(-[[:alpha:]]+(\.[[:digit:]]+)?)?$"
 }
 
 # Get latest semver tag
@@ -77,10 +70,12 @@ main() {
 	local -A latest
 
 	echo "Building tag table..."
-	local major minor patch
-	while IFS=. read -r major minor patch ; do
-		latest["$major"]="$major.$minor.$patch"
-		[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
+	local major minor patch pre prepatch
+	while IFS=".""-" read -r major minor patch pre prepatch ; do
+		[[ ! $pre ]] && latest["$major"]="$major.$minor.$patch"
+		[[ ! $pre ]] && [[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
+		[[ $pre ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pre"
+		[[ $pre ]] && [[ $prepatch ]] latest["$major.$minor-pre"]="$major.$minor.$patch-$pre.$prepatch"
 	done < <(gettags "$prefix")
 
 	# Add "latest" tag if there are tags and the option is set
@@ -106,21 +101,6 @@ main() {
 		echo "Creating annotated tag $tag pointing to same commit as $semvertag..."
 		createannotatedtag "$tag" "$semvertag"
 	done
-
-	# Update prerelease tags
-	if [[ $updateminor == 'true' ]]; then
-		local -A latestpre
-		local pre prepatch
-		while IFS=".""-" read -r major minor patch pre prepatch ; do
-			if [[ $prepatch ]]; then
-				echo $major.$minor.$patch-$pre.$prepatch
-				latestpre["$major.$minor-pre"]="$major.$minor.$patch-$pre.$prepatch"
-			else
-				echo $major.$minor.$patch-$pre
-				latestpre["$major.$minor-pre"]="$major.$minor.$patch-$pre"
-			fi
-		done < <(getpretags "$prefix")
-	fi
 }
 
 [[ ${BASH_SOURCE[0]} == "$0" ]] && main "$@"

--- a/tagupdater
+++ b/tagupdater
@@ -4,6 +4,7 @@
 gettags() {
 	local prefix=$1
 
+	# These patterns have been taken from semver Backus-Naur form grammar https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
 	local numeric="(0|[1-9][0-9]*)"
 	local nondigit="([[:alpha:]]|-)"
 	local identifier="([[:digit:]]|$nondigit)"
@@ -13,8 +14,6 @@ gettags() {
 	local semverregex="$prefix([[:digit:]]+\.){2}[[:digit:]]+"
 	local preregex="(-$prerelease(\.$prerelease)*)"
 	local regex="^$semverregex$preregex?$"
-
-	echo "$regex"
 
 	git tag --list --sort='version:refname' "$prefix*.*.*" \
 		| grep --extended-regexp "$regex"

--- a/tagupdater
+++ b/tagupdater
@@ -66,7 +66,7 @@ main() {
 	echo "Building tag table..."
 	local major minor patch pre prepatch
 	while IFS=".""-" read -r major minor patch pre prepatch ; do
-		if [[ ! $pre ]]
+		if [[ ! $pre ]]; then
 			latest["$major"]="$major.$minor.$patch"
 			[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
 			[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"

--- a/tagupdater
+++ b/tagupdater
@@ -73,11 +73,10 @@ main() {
 	local tag semvertag pretag
 	local major minor patch
 	for tag in $(gettags "$prefix"); do
-		echo "$tag"
 		IFS=- read -r semvertag pretag <<< "$tag"
 		IFS=. read -r major semvertag <<< "$semvertag";
 		IFS=. read -r minor patch <<< "$semvertag";
-		if [[ ! pretag ]]; then
+		if [[ ! $pretag ]]; then
 			latest["$major"]="$major.$minor.$patch"
 			[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
 			[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"

--- a/tagupdater
+++ b/tagupdater
@@ -114,7 +114,7 @@ main() {
 			echo $major.$minor.$patch-$pre.$prepatch
 			if [[ $prepatch ]]; then
 				latestpre["$major.$minor"]="$major.$minor.$patch-$pre.$prepatch"
-			elif
+			else
 				latestpre["$major.$minor"]="$major.$minor.$patch-$pre"
 			fi
 		done < <(getpretags "$prefix")

--- a/tagupdater
+++ b/tagupdater
@@ -68,22 +68,7 @@ main() {
 	echo "Building tag table..."
 	local tag semvertag pretag
 	local major minor patch
-	for tag in gettags "$prefix" do
-		echo "$tag"
-		IFS=- read -r semvertag pretag <<< "$tag"
 
-		while IFS=. read -r major minor patch ; do
-			if [[ ! pretag ]]; then
-				latest["$major"]="$major.$minor.$patch"
-				[[ $updatelatest == 'true' ]] && latest["latest"]="$major.$minor.$patch"
-				[[ $updateminor == 'true' ]] && latest["$major.$minor"]="$major.$minor.$patch"
-			else [[ $updateminor == 'true' ]] && latest["$major.$minor-pre"]="$major.$minor.$patch-$pretag; fi
-		done < "$semvertag"
-	done
-
-	#while IFS=- read -r semver pretag <<< "$s" ; do
-	#	echo "$semver-$pretag"
-	#done < <(gettags "$prefix")
 
 	while IFS=".""-" read -r major minor patch pre prepatch ; do
 		if [[ ! $pre ]]; then


### PR DESCRIPTION
This Pull Request would add support for pre-release tags. See discussion #52 

Changes:
- Change the regex to accept pre-releases according to [Semantic Versioning Backus-Naur form grammar](https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions).
- Add `vX.Y-pre` tags that keeps track of pre-releases.

Fixes:
- Semversions with leading zeros (e.g. `v01.02.03`) will no longer be accepted by the regex.

First tests for this action look promising but it has not been thoroughly tested yet. It is, however, expected to work in all circumstances thanks to applying the Backus-Naur form grammar.

---

It might however be better to take one of SemVer's [suggested regex patterns](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string) to check the string. However, I myself am not skilled enough in bash to understand how to apply those the way they were meant to be applied.