### PR TITLE
Add quotes around tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ name: Update release tags
 on:
   push:
     tags:
-      # Switch to '[0-9]+.[0-9]+.[0-9]+' if prepend-v is false
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      # Switch to '[0-9]+.[0-9]+.[0-9]+' (including the quotes!) if prepend-v
+      # is false
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   update-release-tags:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ on:
   push:
     tags:
       # Switch to '[0-9]+.[0-9]+.[0-9]+' if prepend-v is false
-      - v[0-9]+.[0-9]+.[0-9]+
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   update-release-tags:


### PR DESCRIPTION
If you remove the prepend-v from the tags, you will get a [bad indentation of a sequence entry](https://stackoverflow.com/questions/50259571/bad-indentation-of-a-sequence-entry-bitbucket-pipelines) error. Putting single quotes around the statement fixes that and still works for v.