### PR TITLE
Add permissions and pin runner

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,4 +15,4 @@ permissions:
 jobs:
   lint:
     name: Lint code base
-    uses: bewuethr/workflows/.github/workflows/linter.yml@deep-on-fork
+    uses: bewuethr/workflows/.github/workflows/linter.yml@main

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,7 +7,12 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+  packages: read
+  statuses: write
+
 jobs:
   lint:
     name: Lint code base
-    uses: bewuethr/workflows/.github/workflows/linter.yml@main
+    uses: bewuethr/workflows/.github/workflows/linter.yml@deep-on-fork

--- a/.github/workflows/releasetracker.yml
+++ b/.github/workflows/releasetracker.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
+permissions:
+  contents: write
+
 jobs:
   update-release-tags:
     name: Move tags

--- a/.github/workflows/releasetracker.yml
+++ b/.github/workflows/releasetracker.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
+          show-progress: false
 
       - name: Update release tags for latest major and minor releases
         uses: bewuethr/release-tracker-action@v1

--- a/.github/workflows/releasetracker.yml
+++ b/.github/workflows/releasetracker.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-release-tags:
     name: Move tags
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Check out code

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+<benjamin.wuethrich@gmail.com> <8521043+bewuethr@users.noreply.github.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2023 Benjamin Wuethrich
+Copyright (c) 2020-2024 Benjamin Wuethrich
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
After defaulting to read-only permissions for Actions, permissions have to be set explicitly. This PR does so for the two workflows.

It also

- Pins the runner version for the release tracker workflow
- Suppresses progress for checkout in the release tracker workflow
- Updates the license
- Adds a mailmap