### PR TITLE
Refactor filter

### DIFF
--- a/tagupdater
+++ b/tagupdater
@@ -116,4 +116,8 @@ main() {
 	done
 }
 
-[[ ${BASH_SOURCE[0]} == "$0" ]] && main "$@"
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+	main "$@"
+else
+	true
+fi

--- a/tagupdater
+++ b/tagupdater
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-# List all semver tags and sort them
-gettags() {
+# Filter tags to match SemVer including pre-releases
+filter() {
 	local prefix=$1
 
-	# These patterns have been taken from semver Backus-Naur form grammar https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
+	# These patterns have been taken from semver Backus-Naur form grammar
+	# https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
 	local numeric="(0|[1-9][0-9]*)"
 	local nondigit="([[:alpha:]]|-)"
 	local identifier="([[:digit:]]|$nondigit)"
@@ -15,8 +16,15 @@ gettags() {
 	local preregex="(-$prerelease(\.$prerelease)*)"
 	local regex="^$semverregex$preregex?$"
 
+	grep --extended-regexp "$regex"
+}
+
+# List all semver tags and sort them
+gettags() {
+	local prefix=$1
+
 	git tag --list --sort='version:refname' "$prefix*.*.*" \
-		| grep --extended-regexp "$regex"
+		| filter "$prefix"
 }
 
 # Get SHA of object ref points to

--- a/test/filter.bats
+++ b/test/filter.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+
+load test_helper.bash
+
+@test "Matches v1.0.0" {
+	export -f filter
+	run bash -c 'echo "v1.0.0" | filter "v"'
+	[[ $output == 'v1.0.0' ]]
+}
+
+@test "Matches v1.0.0-alpha" {
+	export -f filter
+	run bash -c 'echo "v1.0.0-alpha" | filter "v"'
+	[[ $output == 'v1.0.0-alpha' ]]
+}
+
+@test "Matches v1.0.0-1" {
+	export -f filter
+	run bash -c 'echo "v1.0.0-1" | filter "v"'
+	[[ $output == 'v1.0.0-1' ]]
+}
+
+@test "Matches v1.0.0-alpha.2" {
+	export -f filter
+	run bash -c 'echo "v1.0.0-alpha.2" | filter "v"'
+	[[ $output == 'v1.0.0-alpha.2' ]]
+}
+
+@test "Does not match non-digit" {
+	export -f filter
+	run bash -c 'echo "v1.0.a" | filter "v"'
+	[[ -z $output ]]
+}
+
+@test "Does not match leading zero" {
+	export -f filter
+	run bash -c 'echo "v01.0.0" | filter "v"'
+	[[ -z $output ]]
+}
+
+@test "Does not match incomplete version" {
+	export -f filter
+	run bash -c 'echo "v1.0" | filter "v"'
+	[[ -z $output ]]
+}
+
+@test "Does not match trailing period" {
+	export -f filter
+	run bash -c 'echo "v1.0." | filter "v"'
+	[[ -z $output ]]
+}
+
+@test "Does not match trailing period on pre-release" {
+	export -f filter
+	run bash -c 'echo "v1.0.0-alpha." | filter "v"'
+	[[ -z $output ]]
+}
+
+@test "Does not match leading period on pre-release" {
+	export -f filter
+	run bash -c 'echo "v1.0.0-.alpha" | filter "v"'
+	[[ -z $output ]]
+}
+
+@test "Does not match patchier than patch" {
+	export -f filter
+	run bash -c 'echo "v1.0.0.0" | filter "v"'
+	[[ -z $output ]]
+}
+
+@test "Does not match empty pre-release" {
+	export -f filter
+	run bash -c 'echo "v1.0.0-" | filter "v"'
+	[[ -z $output ]]
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,0 +1,21 @@
+setup() {
+	# shellcheck source=../tagupdater
+	source tagupdater
+
+	local repo='/tmp/tagupdater-testrepo'
+	mkdir --parents "$repo"
+	git -C "$repo" init --quiet
+
+	if [[ -z $(git -C "$repo" config --get user.name) ]]; then
+		git -C "$repo" config user.name "Integration Test"
+	fi
+	if [[ -z $(git -C "$repo" config --get user.email) ]]; then
+		git -C "$repo" config user.email "integration.test@example.com"
+	fi
+
+	cd /tmp/tagupdater-testrepo || return 1
+}
+
+teardown() {
+	rm -rf /tmp/tagupdater-testrepo
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,5 +1,5 @@
 setup() {
-	# shellcheck source=../tagupdater
+	# shellcheck source=/dev/null
 	source tagupdater
 
 	local repo='/tmp/tagupdater-testrepo'


### PR DESCRIPTION
This moves filtering the tags into a stand-alone function and adds tests for it. The test setup function initializes a Git repo, though the added tests don't require that; the next batch of tests will.

The change to the "don't execute `main` when sourced" bit prevents a non-zero exit status when sourcing the file, which made the test setup fail.