### PR TITLE
Test, and fix gettags

### DIFF
--- a/tagupdater
+++ b/tagupdater
@@ -23,7 +23,7 @@ filter() {
 gettags() {
 	local prefix=$1
 
-	git tag --list --sort='version:refname' "$prefix*.*.*" \
+	git -c versionsort.suffix=- tag --list --sort='version:refname' "$prefix*.*.*" \
 		| filter "$prefix"
 }
 

--- a/test/gettags.bats
+++ b/test/gettags.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load test_helper.bash
+
+@test "Sorts version core tags according to spec" {
+	tags=(
+		v0.1.0
+		v0.1.1
+		v0.2.0
+		v1.0.0
+		v1.0.1
+		v1.1.0
+		v1.2.0
+		v2.0.0
+	)
+
+	for tag in "${tags[@]}"; do
+		git tag "$tag"
+	done
+
+	run gettags 'v'
+
+	# Debug output for failure
+	{
+		printf '%s\t%s\n' 'got' 'want'
+		paste <(echo "$output") <(printf '%s\n' "${tags[@]}")
+	} | column -t
+
+	for ((i = 0; i < ${#tags[@]}; ++i)); do
+		[[ ${lines[i]} == "${tags[i]}" ]]
+	done
+}
+
+@test "Sorts tags with pre-releases according to spec" {
+	tags=(
+		v1.0.0-alpha
+		v1.0.0-alpha.1
+		v1.0.0-alpha.beta
+		v1.0.0-beta
+		v1.0.0-beta.2
+		v1.0.0-beta.11
+		v1.0.0-rc.1
+		v1.0.0
+	)
+
+	for tag in "${tags[@]}"; do
+		git tag "$tag"
+	done
+
+	run gettags 'v'
+
+	# Debug output for failure
+	{
+		printf '%s\t%s\n' 'got' 'want'
+		paste <(printf '%s\n' "${lines[@]}") <(printf '%s\n' "${tags[@]}")
+	} | column -t
+
+	for ((i = 0; i < ${#tags[@]}; ++i)); do
+		[[ ${lines[i]} == "${tags[i]}" ]]
+	done
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -14,6 +14,11 @@ setup() {
 	fi
 
 	cd /tmp/tagupdater-testrepo || return 1
+
+	touch afile
+	git add afile
+	git commit -m "Add file"
+
 }
 
 teardown() {


### PR DESCRIPTION
This adds tests for the gettags function. To enable tagging in the test Git repo, the setup function creates a commit with an empty file first.

The command to list tags sorted by version

```sh
git tag --list --sort='version:refname'
```

incorrectly sorts all pre-releases after the main release, like

```none
v1.0.0
v1.0.0-alpha
v1.0.0-beta
```

To fix this, the call is updated with a call-scoped configuration setting to sort any version with a suffix starting with `-` (which is all pre-releases) *before* a main release:

```sh
git -c versionsort.suffix=- tag --list --sort='version:refname'
```

resulting in the correct

```none
v1.0.0-alpha
v1.0.0-beta
v1.0.0
```

The `versionsort.suffix` setting theoretically can re-order any pre-release suffixes in arbitrary order, enabling things like

```none
v1.0.0-alpha
v1.0.0-beta
v1.0.0-gamma
v1.0.0-delta
v1.0.0
```

where `delta` would usually be sorted before `gamma`. This could be configured via Action input, but I'll leave it for now.